### PR TITLE
feat: auto focus text on visualization change

### DIFF
--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -443,6 +443,15 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
   const [isSearchFocused, setIsSearchFocused] = useState(true);
   const isActivelySearching = isSearchFocused && !!searchInputValue;
 
+  // auto-focus the search input when the modal opens
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      searchInputRef.current?.focus();
+    }, 200);
+
+    return () => clearTimeout(timer);
+  }, []);
+
   const selectedVizMetadata: ChartMetadata | null = selectedViz
     ? mountedPluginMetadata[selectedViz]
     : null;


### PR DESCRIPTION
### SUMMARY
This PR adds auto-focus functionality to the search input field when the "Change Visualization Type" modal opens. Previously, users had to manually click on the search input before they could start typing to search for visualization types. This change improves the user workflow by eliminating an unnecessary click and follows common modal interaction patterns.

**Technical implementation:**
- Implemented `useEffect` hook to automatically focus the input when the modal mounts
- Ensures keyboard-friendly navigation for power users

### BEFORE/AFTER SCREENSHOTS 
**Before:**
<img width="1528" height="858" alt="image" src="https://github.com/user-attachments/assets/05022a7d-7287-4c59-96e1-de7e45223673" />

**After:**
<img width="1382" height="851" alt="image" src="https://github.com/user-attachments/assets/d1d0b40f-f9f3-4a2f-a574-909a0d9c18e4" />


### Video Demo
[[Video demo showing the before/after behavior and code walkthrough]](https://github.com/user-attachments/assets/61ff78d6-329c-4fa1-96aa-c8d4308cfde6)

### TESTING INSTRUCTIONS
1. Open any chart in Explore view
2. Click the "View all charts" button
3. Verify the modal opens with the cursor automatically focused in the search input field
4. Verify you can immediately start typing without clicking
5. Verify the search functionality works as expected

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #4
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
