### PR TITLE
feat(table-chart): add configurable percentage calculation mode

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/types/PostProcessing.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/PostProcessing.ts
@@ -97,6 +97,7 @@ interface _PostProcessingContribution {
     orientation?: 'row' | 'column';
     columns?: string[];
     rename_columns?: string[];
+    percentage_calculation_mode?: 'row_limit' | 'all_records';
   };
 }
 export type PostProcessingContribution =

--- a/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
@@ -151,6 +151,7 @@ const buildQuery: BuildQuery<TableChartFormData> = (
             options: {
               columns: percentMetricLabels,
               rename_columns: percentMetricLabels.map(x => `%${x}`),
+              percentage_calculation_mode: formData.percentage_calculation_mode,
             },
           },
         ];

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -186,6 +186,25 @@ const processComparisonColumns = (columns: any[], suffix: string) =>
     })
     .flat();
 
+const percentageCalculationModeControl: ControlConfig<'SelectControl'> = {
+  type: 'SelectControl',
+  label: t('Percentage metric calculation'),
+  description: t(
+    'Choose how percentage metrics are calculated. "Row limit" calculates ' +
+      'percentages based on visible rows only. "All records" calculates ' +
+      'percentages based on the entire dataset.',
+  ),
+  default: 'row_limit',
+  choices: [
+    ['row_limit', t('Row limit')],
+    ['all_records', t('All records')],
+  ],
+  visibility: ({ controls }: ControlPanelsContainerProps) =>
+    isAggMode({ controls }) &&
+    ensureIsArray(controls?.percent_metrics?.value).length > 0,
+  renderTrigger: true,
+};
+
 const config: ControlPanelConfig = {
   controlPanelSections: [
     {
@@ -297,6 +316,12 @@ const config: ControlPanelConfig = {
           {
             name: 'percent_metrics',
             config: percentMetricsControl,
+          },
+        ],
+        [
+          {
+            name: 'percentage_calculation_mode', // NEW CONTROL
+            config: percentageCalculationModeControl,
           },
         ],
         ['adhoc_filters'],

--- a/superset-frontend/plugins/plugin-chart-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/types.ts
@@ -82,6 +82,7 @@ export type TableChartFormData = QueryFormData & {
   page_length?: string | number | null; // null means auto-paginate
   metrics?: QueryFormMetric[] | null;
   percent_metrics?: QueryFormMetric[] | null;
+  percentage_calculation_mode?: string;
   timeseries_limit_metric?: QueryFormMetric[] | QueryFormMetric | null;
   groupby?: QueryFormMetric[] | null;
   all_columns?: QueryFormMetric[] | null;

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -917,6 +917,15 @@ class ChartDataPostProcessingOperationSchema(Schema):
         },
     )
 
+    percentage_calculation_mode = fields.String(
+        metadata={
+            "description": "Mode for calculating percentage metrics",
+            "example": "row_limit",
+        },
+        validate=validate.OneOf(choices=["row_limit", "all_records"]),
+        load_default="row_limit",
+    )
+
 
 class ChartDataFilterSchema(Schema):
     col = fields.Raw(

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -282,6 +282,9 @@ class QueryContextProcessor:
                 query += ";\n\n".join(queries)
                 query += ";\n\n"
 
+            # Inject totals for "all_records" percentage calculation mode
+            self._inject_percentage_totals(query_object, df)
+
             # Re-raising QueryObjectValidationError
             try:
                 df = query_object.exec_post_processing(df)
@@ -903,6 +906,70 @@ class QueryContextProcessor:
             return {"records": payload["queries"][0]["data"]}
         except SupersetException as ex:
             raise QueryObjectValidationError(error_msg_from_exception(ex)) from ex
+
+    def _inject_percentage_totals(
+        self, query_object: QueryObject, df: pd.DataFrame
+    ) -> None:
+        """
+        Inject totals into contribution post-processing operation when
+        percentage_calculation_mode is 'all_records'.
+        
+        :param query_object: The query object being processed
+        :param df: The current DataFrame (with row_limit applied)
+        """
+        # Check if there's a contribution operation with all_records mode
+        for post_process in query_object.post_processing:
+            if post_process.get("operation") == "contribution":
+                options = post_process.get("options", {})
+                mode = options.get("percentage_calculation_mode", "row_limit")
+                
+                if mode == "all_records":
+                    # Get numeric columns that will be used for contribution
+                    columns = options.get("columns") or []
+                    if not columns:
+                        # If no columns specified, use all numeric columns
+                        columns = df.select_dtypes(include=["number"]).columns.tolist()
+                    
+                    # Calculate totals from the full dataset
+                    totals = self._fetch_metric_totals(query_object, columns)
+                    
+                    # Inject totals into the operation options
+                    options["totals"] = totals
+
+    def _fetch_metric_totals(
+        self, query_object: QueryObject, metric_columns: list[str]
+    ) -> dict[str, float]:
+        """
+        Execute a query to get totals for specified metrics without row limit.
+        
+        :param query_object: The original query object
+        :param metric_columns: List of metric column names to sum
+        :return: Dictionary mapping column names to their totals
+        """
+        query_context = self._query_context
+        
+        # Create a modified query dict for totals calculation
+        query_dict = query_object.to_dict()
+        
+        # Remove row limit , offset and group by columns
+        query_dict["row_limit"] = None
+        query_dict["row_offset"] = None
+        query_dict["columns"] = []
+        
+        # Execute the optimized aggregation query
+        if isinstance(query_context.datasource, Query):
+            result = query_context.datasource.exc_query(query_dict)
+        else:
+            result = query_context.datasource.query(query_dict)
+        
+        # Extract totals from the single result row
+        totals = {}
+        if not result.df.empty:
+            for col in metric_columns:
+                if col in result.df.columns:
+                    totals[col] = float(result.df[col].iloc[0])
+        
+        return totals
 
     def raise_for_access(self) -> None:
         """

--- a/superset/utils/pandas_postprocessing/contribution.py
+++ b/superset/utils/pandas_postprocessing/contribution.py
@@ -37,6 +37,8 @@ def contribution(
     columns: list[str] | None = None,
     time_shifts: list[str] | None = None,
     rename_columns: list[str] | None = None,
+    totals: dict[str, float] | None = None,
+    percentage_calculation_mode: str | None = None,
 ) -> DataFrame:
     """
     Calculate cell contribution to row/column total for numeric columns.
@@ -52,6 +54,8 @@ def contribution(
     :param rename_columns: The new labels for the calculated contribution columns.
                            The original columns will not be removed.
     :param orientation: calculate by dividing cell with row/column total
+    :param totals: Optional dict of column totals for "all_records" mode
+    :param percentage_calculation_mode: "row_limit" or "all_records" mode
     :return: DataFrame with contributions.
     """
     contribution_df = df.copy()
@@ -82,10 +86,20 @@ def contribution(
     numeric_df_view = numeric_df[actual_columns]
 
     if orientation == PostProcessingContributionOrientation.COLUMN:
-        numeric_df_view = numeric_df_view / numeric_df_view.values.sum(
-            axis=0, keepdims=True
-        )
-        contribution_df[rename_columns] = numeric_df_view
+        if totals:
+            # All Records mode
+            for idx, col in enumerate(actual_columns):
+                total = totals.get(col, numeric_df_view[col].sum())
+                # Convert to Decimal if needed to match DataFrame dtype
+                if isinstance(numeric_df_view[col].iloc[0] if len(numeric_df_view[col]) > 0 else 0, Decimal):
+                    total = Decimal(str(total))
+                contribution_df[rename_columns[idx]] = numeric_df_view[col] / total
+        else:
+            # Row Limit mode
+            numeric_df_view = numeric_df_view / numeric_df_view.values.sum(
+                axis=0, keepdims=True
+            )
+            contribution_df[rename_columns] = numeric_df_view
         return contribution_df
 
     result = get_column_groups(numeric_df_view, time_shifts, rename_columns)

--- a/tests/unit_tests/common/test_query_context_processor.py
+++ b/tests/unit_tests/common/test_query_context_processor.py
@@ -236,3 +236,75 @@ def test_get_data_xlsx_apply_column_types_error(
     mock_query_context.result_format = ChartDataResultFormat.XLSX
     with pytest.raises(ValueError, match="Conversion error"):
         processor.get_data(df, coltypes)
+
+
+def test_inject_percentage_totals_row_limit_mode():
+    """Test that row_limit mode doesn't inject totals"""
+    from superset.common.query_object import QueryObject
+
+    mock_qc = MagicMock()
+    processor = QueryContextProcessor(mock_qc)
+
+    # Create a mock query object with contribution post-processing
+    query_object = MagicMock(spec=QueryObject)
+    query_object.post_processing = [
+        {
+            "operation": "contribution",
+            "options": {
+                "columns": ["sales"],
+                "percentage_calculation_mode": "row_limit",
+            },
+        }
+    ]
+
+    df = pd.DataFrame({"category": ["A", "B"], "sales": [100, 200]})
+
+    # Should not add totals for row_limit mode
+    processor._inject_percentage_totals(query_object, df)
+
+    # Verify totals were NOT injected
+    assert "totals" not in query_object.post_processing[0]["options"]
+
+
+def test_inject_percentage_totals_all_records_mode():
+    """Test that all_records mode injects totals"""
+    from superset.common.query_object import QueryObject
+    from superset.models.helpers import QueryResult
+
+    mock_qc = MagicMock()
+    mock_datasource = MagicMock()
+
+    # Mock the query result with totals
+    mock_result = MagicMock(spec=QueryResult)
+    mock_result.df = pd.DataFrame({"sales": [1000.0]})  # Total from all records
+    mock_datasource.query.return_value = mock_result
+
+    mock_qc.datasource = mock_datasource
+    processor = QueryContextProcessor(mock_qc)
+
+    # Create a mock query object
+    query_object = MagicMock(spec=QueryObject)
+    query_object.post_processing = [
+        {
+            "operation": "contribution",
+            "options": {
+                "columns": ["sales"],
+                "percentage_calculation_mode": "all_records",
+            },
+        }
+    ]
+    query_object.to_dict.return_value = {
+        "columns": ["category"],
+        "metrics": ["sales"],
+        "row_limit": 10,
+    }
+
+    df = pd.DataFrame({"category": ["A", "B"], "sales": [100, 200]})
+
+    # Should inject totals for all_records mode
+    processor._inject_percentage_totals(query_object, df)
+
+    # Verify totals were injected
+    assert "totals" in query_object.post_processing[0]["options"]
+    assert query_object.post_processing[0]["options"]["totals"] == {"sales": 1000.0}
+

--- a/tests/unit_tests/pandas_postprocessing/test_contribution.py
+++ b/tests/unit_tests/pandas_postprocessing/test_contribution.py
@@ -124,3 +124,80 @@ def test_contribution_with_time_shift_columns():
     assert_array_equal(processed_df["a__1 week ago"].tolist(), [0.5, 0.5])
     assert_array_equal(processed_df["b__1 week ago"].tolist(), [0.25, 0.25])
     assert_array_equal(processed_df["c__1 week ago"].tolist(), [0.25, 0.25])
+
+
+def test_contribution_with_row_limit_mode():
+    """Test percentage calculation with row_limit mode (default behavior)"""
+    df = DataFrame(
+        {
+            "category": ["A", "B", "C"],
+            "sales": [100, 200, 300],
+        }
+    )
+    # Default mode (row_limit) - percentages based on current df
+    processed_df = contribution(
+        df,
+        orientation=PostProcessingContributionOrientation.COLUMN,
+        columns=["sales"],
+        rename_columns=["pct_sales"],
+        percentage_calculation_mode="row_limit",
+    )
+    assert processed_df.columns.tolist() == ["category", "sales", "pct_sales"]
+    # Total is 600, so percentages are 100/600, 200/600, 300/600
+    assert_array_equal(
+        processed_df["pct_sales"].tolist(), [100 / 600, 200 / 600, 300 / 600]
+    )
+
+
+def test_contribution_with_all_records_mode():
+    """Test percentage calculation with all_records mode using provided totals"""
+    df = DataFrame(
+        {
+            "category": ["A", "B", "C"],
+            "sales": [100, 200, 300],
+        }
+    )
+    # all_records mode with totals from full dataset
+    # Simulate that total sales across ALL records is 10000
+    totals = {"sales": 10000.0}
+    processed_df = contribution(
+        df,
+        orientation=PostProcessingContributionOrientation.COLUMN,
+        columns=["sales"],
+        rename_columns=["pct_sales"],
+        totals=totals,
+        percentage_calculation_mode="all_records",
+    )
+    assert processed_df.columns.tolist() == ["category", "sales", "pct_sales"]
+    # Percentages based on total of 10000
+    assert_array_equal(
+        processed_df["pct_sales"].tolist(), [100 / 10000, 200 / 10000, 300 / 10000]
+    )
+
+
+def test_contribution_with_totals_multiple_columns():
+    """Test percentage calculation with totals for multiple columns"""
+    df = DataFrame(
+        {
+            "category": ["A", "B"],
+            "sales": [100, 200],
+            "profit": [10, 20],
+        }
+    )
+    totals = {"sales": 1000.0, "profit": 100.0}
+    processed_df = contribution(
+        df,
+        orientation=PostProcessingContributionOrientation.COLUMN,
+        columns=["sales", "profit"],
+        rename_columns=["pct_sales", "pct_profit"],
+        totals=totals,
+    )
+    assert processed_df.columns.tolist() == [
+        "category",
+        "sales",
+        "profit",
+        "pct_sales",
+        "pct_profit",
+    ]
+    assert_array_equal(processed_df["pct_sales"].tolist(), [100 / 1000, 200 / 1000])
+    assert_array_equal(processed_df["pct_profit"].tolist(), [10 / 100, 20 / 100])


### PR DESCRIPTION
### SUMMARY

Adds a new control to Table charts that allows users to choose how percentage metrics are calculated:

**Row Limit Mode** (default): Percentages are calculated based only on the visible rows returned by the row limit. This maintains backward compatibility with existing behavior.

**All Records Mode** (new): Percentages are calculated against the total from the entire dataset, providing true contribution percentages even when viewing a limited subset of data.

#### Problem Solved
Previously, when users added a row limit to table charts with percentage metrics, the percentages would sum to 100% based only on the visible rows, not the entire dataset. This was misleading when trying to understand each row's true contribution to the overall total.

For example, if viewing the top 10 products by sales from a dataset of 1000 products:
- **Before**: Top 10 percentages sum to 100% (misleading - makes it appear these are the only products)
- **After**: Top 10 percentages sum to their actual contribution (e.g., 27.5% of total sales)

#### Implementation Details

**Backend Changes:**
- Modified `contribution()` function to accept optional `totals` dict and `percentage_calculation_mode` parameter
- Added `_inject_percentage_totals()` method to detect "all_records" mode and fetch totals
- Added `_fetch_metric_totals()` method to fetch the overall total

**Frontend Changes:**
- Added "Percentage metric calculation" dropdown control to table chart configuration
- Passes selected mode to backend via post-processing operation options


### BEFORE/AFTER SCREENSHOTS & DEMO

**BEFORE:**
<img width="1913" height="948" alt="image" src="https://github.com/user-attachments/assets/b32debf4-9f02-4817-ab0b-5de25be56953" />


**AFTER (All Records Mode - New Option):**
<img width="1909" height="954" alt="image" src="https://github.com/user-attachments/assets/d4ecde23-bb4e-4f7d-a5f1-fbddb6372852" />


**DEMO**
https://youtu.be/2RxnPQj9LTE


### TESTING INSTRUCTIONS

#### Manual Testing:
1. Create or open a Table chart in Explore view
2. Add a dataset with numerical data (e.g., sales, revenue)
3. Set query mode to "Aggregate"
4. Add a metric (e.g., `SUM(sales)`)
5. Add the same metric to "Percentage metrics"
6. Set Row limit to 10
7. Click "Run Query"
8. **Verify Row Limit Mode (default):**
   - Check that percentages in the % column sum to ~100%
9. **Switch to All Records Mode:**
   - Find "Percentage metric calculation" control
   - Select "All records"
   - Click "Update Table"
10. **Verify All Records Mode:**
    - Check that percentages now sum to less than 100% (showing true contribution)
    - Verify percentages are calculated against full dataset total


### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes https://github.com/BPATHAK10/superset/issues/13
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API