### PR TITLE
feat: added data zoom functionalily to boxplot chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts
@@ -157,6 +157,18 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        [
+          {
+            name: 'zoomable',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Data Zoom'),
+              default: false,
+              renderTrigger: true,
+              description: t('Enable data zooming controls'),
+            },
+          },
+        ],
       ],
     },
   ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/transformProps.ts
@@ -39,7 +39,7 @@ import {
 import { convertInteger } from '../utils/convertInteger';
 import { defaultGrid, defaultYAxis } from '../defaults';
 import { getPadding } from '../Timeseries/transformers';
-import { OpacityEnum } from '../constants';
+import { OpacityEnum, TIMESERIES_CONSTANTS } from '../constants';
 import { getDefaultTooltip } from '../utils/tooltip';
 import { Refs } from '../types';
 
@@ -74,6 +74,7 @@ export default function transformProps(
     yAxisTitlePosition,
     sliceId,
   } = formData as BoxPlotQueryFormData;
+  const { zoomable = false } = formData as BoxPlotQueryFormData;
   const refs: Refs = {};
   const colorFn = CategoricalColorNamespace.getScale(colorScheme as string);
   const numberFormatter = getNumberFormatter(numberFormat);
@@ -247,7 +248,7 @@ export default function transformProps(
     true,
     legendOrientation,
     addYAxisTitleOffset,
-    false,
+    zoomable,
     null,
     addXAxisTitleOffset,
     yAxisTitlePosition,
@@ -283,6 +284,23 @@ export default function transformProps(
         type: 'shadow',
       },
     },
+    ...(zoomable && {
+      dataZoom: [
+        {
+          type: 'slider',
+          start: TIMESERIES_CONSTANTS.dataZoomStart,
+          end: TIMESERIES_CONSTANTS.dataZoomEnd,
+          bottom: TIMESERIES_CONSTANTS.zoomBottom,
+          xAxisIndex: 0,
+        },
+        {
+          type: 'inside',
+          xAxisIndex: 0,
+          zoomOnMouseWheel: false,
+          moveOnMouseWheel: true,
+        },
+      ],
+    }),
     series,
   };
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/types.ts
@@ -30,6 +30,7 @@ export type BoxPlotQueryFormData = QueryFormData & {
   numberFormat?: string;
   whiskerOptions?: BoxPlotFormDataWhiskerOptions;
   xTickLayout?: BoxPlotFormXTickLayout;
+  zoomable?: boolean;
 } & TitleFormData;
 
 export type BoxPlotFormDataWhiskerOptions =
@@ -50,6 +51,7 @@ export type BoxPlotFormXTickLayout =
 // @ts-ignore
 export const DEFAULT_FORM_DATA: BoxPlotQueryFormData = {
   ...DEFAULT_TITLE_FORM_DATA,
+  zoomable: false,
 };
 
 export interface EchartsBoxPlotChartProps


### PR DESCRIPTION
### SUMMARY

This PR adds interactive data zoom capabilities to the BoxPlot chart plugin, enabling users to explore dense datasets with many categories more effectively. The implementation follows the established pattern from Timeseries charts, reusing ECharts' built-in `DataZoomComponent` for consistency and maintainability.

**Key Changes:**
- Added a new `zoomable` control (checkbox) in the BoxPlot chart configuration panel under "Chart Options"
- Implemented conditional `dataZoom` (reusing ECharts DataZoomComponent) injection in `transformProps` when zoom is enabled


### BEFORE/AFTER SCREENSHOTS 

**BEFORE:**
<img width="1916" height="930" alt="image" src="https://github.com/user-attachments/assets/7e0d6a3d-8a8d-4153-b76a-f7a361dd9eb7" />


**AFTER:**
<img width="1913" height="933" alt="image" src="https://github.com/user-attachments/assets/4447bebf-fd39-4102-9300-4fa45bf2f337" />

**DEMO:**

https://github.com/user-attachments/assets/ffefcaa5-db5e-48c2-8e3f-12d8d837bb65

### TESTING INSTRUCTIONS

#### Manual Testing Steps

1. Create or edit a BoxPlot chart in Superset
2. Locate and enable the zoom control option in the chart configuration panel
3. Save and render the chart
4. Use mouse wheel to pan through the chart horizontally
5. Verify that the chart responds to mouse interactions and allows navigation through the data
6. Disable the zoom control and verify the chart returns to static behavior

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes [#15](https://github.com/BPATHAK10/superset/issues/26)
- [ ] Required feature flags: None
- [x] Changes UI (adds zoom slider and toolbox when enabled)
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API (adds `zoomable` control to BoxPlot formData)
- [ ] Removes existing feature or API